### PR TITLE
Remove a hidden infinite loop and re-enable loading

### DIFF
--- a/mmm_common/ModFolder.cpp
+++ b/mmm_common/ModFolder.cpp
@@ -99,8 +99,9 @@ namespace mmm
 			//Get the app data path where some things may be stored.
 			const std::string appdata = getAppdataPath();
 
+			bool fleetops = INVALID_HANDLE_VALUE != GetModuleHandle(L"FleetOpsHook.dll");
 			//Extra options if we are running in fleet operations.
-			if( common::Storage::instance().fleetops )
+			if( fleetops )
 			{
 				std::string mod = getModName();
 				if( !mod.empty() )

--- a/mmm_loader/Main.cpp
+++ b/mmm_loader/Main.cpp
@@ -89,7 +89,7 @@ namespace mmm
 			return 51;
 		}
 
-		//SetupReload( param );
+		SetupReload( param );
 
 		mmm::setScriptInterface( param );
 


### PR DESCRIPTION
The static instance of `Storage` has a `ModFolder` member variable - however the constructor of this class uses the static `Storage` instance so it was hanging on loading the dll.
Also re-enable the reload function to allow the `resume` function to work again.
Closes #10