### PR TITLE
Fix print incorrectly removing messages

### DIFF
--- a/mmm_armada/Globals.cpp
+++ b/mmm_armada/Globals.cpp
@@ -45,20 +45,19 @@ namespace mmm
 		storage.path = oldPath;
 	}
 
-	void
-	globals_print( const std::string& str )
+	void globals_print(const std::string& str)
 	{
-		PrintMessages::add( str, DebuggerConnection::Type_Message );
+		print::add( str, DebuggerConnection::Type_Message );
 	}
 
-	void
-	globals_register( lua_State* state )
+	void globals_register(lua_State* state)
 	{
 		using namespace luabind;
 		module(state)
 		[
 			def( "include", &globals_include ),
-			def( "print", &globals_print )
+			def( "print", &globals_print ),
+			def( "clearPrint", &print::clear )
 		];
 	}
 }

--- a/mmm_armada/PrintMessages.cpp
+++ b/mmm_armada/PrintMessages.cpp
@@ -51,7 +51,7 @@ namespace mmm
             };
 
             std::array<Message, 20> messages;
-            int32_t current_index{ 0 };
+            std::size_t current_index{ 0 };
 
             /// <summary>
             /// Find the next available message slot.
@@ -74,12 +74,12 @@ namespace mmm
             }
             else
             {
-                std::size_t newIndex = next_index();
-                if (messages[newIndex].valid())
+                const std::size_t new_index = next_index();
+                if (messages[new_index].valid())
                 {
-                    messages[newIndex].remove();
+                    messages[new_index].remove();
                 }
-                messages[newIndex].set(message, newIndex);
+                messages[new_index].set(message, new_index);
             }
         }
 

--- a/mmm_armada/PrintMessages.cpp
+++ b/mmm_armada/PrintMessages.cpp
@@ -1,6 +1,5 @@
 #include "PrintMessages.h"
 #include "UI_Internal.h"
-#include "DebuggerConnection.h"
 #include <array>
 
 namespace mmm

--- a/mmm_armada/PrintMessages.h
+++ b/mmm_armada/PrintMessages.h
@@ -4,13 +4,17 @@
 
 namespace mmm
 {
-	class PrintMessages
-	{
-	public:
-		static void add( const std::string& message, DebuggerConnection::Type type = DebuggerConnection::Type_Message );
-	private:
-		static std::size_t getIndex( );
-		static std::vector< std::pair<int,float> > messages_;
-		static int					currentIndex_;
-	};
+    namespace print
+    {
+        /// <summary>
+        /// Add a print message to the next available message slot.
+        /// </summary>
+        /// <param name="message">The message to show.</param>
+        /// <param name="type">Type for MMM debugger.</param>
+        void add(const std::string& message, DebuggerConnection::Type type = DebuggerConnection::Type_Message);
+        /// <summary>
+        /// Clear all message slots.
+        /// </summary>
+        void clear();
+    }
 }

--- a/mmm_armada/ScriptErrors.cpp
+++ b/mmm_armada/ScriptErrors.cpp
@@ -4,10 +4,9 @@
 
 namespace mmm
 {
-	void 
-	scriptError( const std::string& error, bool stop )
+	void scriptError( const std::string& error, bool stop )
 	{
-		PrintMessages::add( error, DebuggerConnection::Type_Error );
+		print::add( error, DebuggerConnection::Type_Error );
 		common::Storage::instance().error = stop;
 	}
 

--- a/mmm_armada/Test.cpp
+++ b/mmm_armada/Test.cpp
@@ -51,7 +51,7 @@ namespace mmm
 			
 			call_function<void>( function_ );
 
-			PrintMessages::add( "Pass:" + name_, DebuggerConnection::Type_Test );
+			print::add( "Pass:" + name_, DebuggerConnection::Type_Test );
 		}
 		catch( const luabind::error& e )
 		{
@@ -65,7 +65,7 @@ namespace mmm
 				actualError = actualError.substr(startIndex + 1, endIndex - startIndex - 1);
 			}
 
-			PrintMessages::add( "Fail:" + name_ + ":" + actualError, DebuggerConnection::Type_Test );
+			print::add( "Fail:" + name_ + ":" + actualError, DebuggerConnection::Type_Test );
 		}
 	}
 }


### PR DESCRIPTION
`print` was removing messages that were never set as IDs were set to 0 before - sending this through to A2's `removeMessage` was removing the first message even if that wasn't the ID returned.

Set all IDs to a default value (-1) and check against that before removing the message. Also tidied up the code a little and moved the functions to namespace level instead of being static functions in a class.

Added a new global function `clearPrint`. This removes all current print messages.

Closes #19 