### PR TITLE
Stop all nebula rotation by default

### DIFF
--- a/mmm_armada/NebulaBinding.cpp
+++ b/mmm_armada/NebulaBinding.cpp
@@ -2,18 +2,16 @@
 
 namespace mmm
 {
-	void
-	nebula_register( lua_State* state )
-	{
-		using namespace luabind;
-
-		module(state)
-		[
-			class_<Nebula, AreaEffectObject, EntityPtr>( "Nebula" )
-				//.property( "allowConstruction", &Nebula::getCanBuildInNebula, &Nebula::setCanBuildInNebula )
-				//.property( "deltaRoll", &Nebula::getDeltaRoll, &Nebula::setDeltaRoll )
-				//.property( "deltaYaw", &Nebula::getDeltaYaw, &Nebula::setDeltaYaw )
-				//.property( "deltaPitch", &Nebula::getDeltaPitch, &Nebula::setDeltaPitch )
-		];
-	}
+    void nebula_register( lua_State* state )
+    {
+        using namespace luabind;
+        module(state)
+        [
+            class_<Nebula, AreaEffectObject, EntityPtr>("Nebula")
+                .property("allowConstruction", &Nebula::getCanBuildInNebula, &Nebula::setCanBuildInNebula)
+                .property("deltaRoll", &Nebula::getDeltaRoll, &Nebula::setDeltaRoll)
+                .property("deltaYaw", &Nebula::getDeltaYaw, &Nebula::setDeltaYaw)
+                .property("deltaPitch", &Nebula::getDeltaPitch, &Nebula::setDeltaPitch)
+        ];
+    }
 }

--- a/mmm_armada/Nebula_Internal.cpp
+++ b/mmm_armada/Nebula_Internal.cpp
@@ -3,75 +3,63 @@
 
 namespace mmm
 {
-	NebulaPtr
-	Nebula::create( types::Entity* entity )
-	{
-		return NebulaPtr( new Nebula( static_cast<types::Nebula*>( entity ) ) );
-	}
+    NebulaPtr Nebula::create(types::Entity* entity)
+    {
+        return NebulaPtr(new Nebula(static_cast<types::Nebula*>( entity )));
+    }
 
-	Nebula::Nebula( types::Nebula* nebula )
-		: AreaEffectObject( nebula )
-	{
+    Nebula::Nebula(types::Nebula* nebula)
+        : AreaEffectObject(nebula)
+    {
+    }
 
-	}
+    bool Nebula::getCanBuildInNebula() const
+    {
+        return getNebula()->m_canWeBuildInHere;
+    }
 
-	bool
-	Nebula::getCanBuildInNebula( ) const
-	{
-		return getNebula()->m_canWeBuildInHere;
-	}
+    void Nebula::setCanBuildInNebula(bool value)
+    {
+        getNebula()->m_canWeBuildInHere = value;
+    }
 
-	void
-	Nebula::setCanBuildInNebula( bool value )
-	{
-		getNebula()->m_canWeBuildInHere = value;
-	}
+    float Nebula::getDeltaRoll() const
+    {
+        return getNebula()->delta_roll;
+    }
 
-	float	
-	Nebula::getDeltaRoll( ) const
-	{
-		return getNebula()->delta_roll;
-	}
-		
-	float 
-	Nebula::getDeltaPitch( ) const
-	{
-		return getNebula()->delta_pitch;
-	}
-		
-	float
-	Nebula::getDeltaYaw() const
-	{
-		return getNebula()->delta_yaw;
-	}
+    float Nebula::getDeltaPitch() const
+    {
+        return getNebula()->delta_pitch;
+    }
 
-	void			
-	Nebula::setDeltaRoll( float value )
-	{
-		getNebula()->delta_roll = value;
-	}
-		
-	void			
-	Nebula::setDeltaPitch( float value )
-	{
-		getNebula()->delta_pitch = value;
-	}
-		
-	void			
-	Nebula::setDeltaYaw( float value )
-	{
-		getNebula()->delta_yaw = value;
-	}
+    float Nebula::getDeltaYaw() const
+    {
+        return getNebula()->delta_yaw;
+    }
 
-	types::Nebula*
-	Nebula::getNebula( ) const
-	{
-		return static_cast<types::Nebula*>( getEntity() );
-	}
+    void Nebula::setDeltaRoll(float value)
+    {
+        getNebula()->delta_roll = value;
+    }
 
-	void
-	Nebula::allocateReplacement( luabind::detail::object_rep* obj )
-	{
-		entity_allocate_replacement<Nebula>( obj, boost::static_pointer_cast<Nebula>( shared_from_this() ) );
-	}
+    void Nebula::setDeltaPitch(float value)
+    {
+        getNebula()->delta_pitch = value;
+    }
+
+    void Nebula::setDeltaYaw(float value)
+    {
+        getNebula()->delta_yaw = value;
+    }
+
+    types::Nebula* Nebula::getNebula() const
+    {
+        return static_cast<types::Nebula*>(getEntity());
+    }
+
+    void Nebula::allocateReplacement(luabind::detail::object_rep* obj)
+    {
+        entity_allocate_replacement<Nebula>(obj, boost::static_pointer_cast<Nebula>(shared_from_this()));
+    }
 }

--- a/mmm_armada/Nebula_Internal.h
+++ b/mmm_armada/Nebula_Internal.h
@@ -4,26 +4,25 @@
 
 namespace mmm
 {
-	namespace types { struct Nebula; };
+    namespace types { struct Nebula; };
 
-	class Nebula
-		: public AreaEffectObject
-	{
-	public:
-		static NebulaPtr create( types::Entity* entity );
-		bool			getCanBuildInNebula( ) const;
-		void			setCanBuildInNebula( bool value );
-		float			getDeltaRoll( ) const;
-		float			getDeltaPitch( ) const;
-		float			getDeltaYaw( ) const;	
-		void			setDeltaRoll( float value );
-		void			setDeltaPitch( float value );
-		void			setDeltaYaw( float value );
-		types::Nebula*	getNebula() const;
-	protected:
-		virtual void   allocateReplacement( luabind::detail::object_rep* object );
-		explicit	   Nebula( types::Nebula* nebula );
-	};
+    class Nebula : public AreaEffectObject
+    {
+    public:
+        static NebulaPtr create(types::Entity* entity);
+        bool getCanBuildInNebula() const;
+        void setCanBuildInNebula(bool value);
+        float getDeltaRoll() const;
+        float getDeltaPitch() const;
+        float getDeltaYaw() const;
+        void setDeltaRoll(float value);
+        void setDeltaPitch(float value);
+        void setDeltaYaw(float value);
+        types::Nebula* getNebula() const;
+    protected:
+        virtual void allocateReplacement(luabind::detail::object_rep* object);
+        explicit Nebula(types::Nebula* nebula);
+    };
 
-	void nebula_register( lua_State* state );
+    void nebula_register(lua_State* state);
 }

--- a/mmm_loader/Worker.cpp
+++ b/mmm_loader/Worker.cpp
@@ -7,6 +7,9 @@
 #include "../mmm_armada/Debug_Internal.h"
 #include "../mmm_armada/Media_Internal.h"
 #include "../mmm_armada/Game_Internal.h"
+#include "../mmm_armada/Entities_Internal.h"
+#include "../mmm_armada/Nebula_Internal.h"
+#include "../mmm_armada/Type_Nebula.h"
 
 namespace mmm
 {
@@ -106,6 +109,26 @@ namespace mmm
 				VirtualProtect(instruction, 2, old_protect, &old_protect);
 			}
 		}
+
+		/// <summary>
+		/// Stop all nebula rotation by default as they already rotate in animation - this
+		/// extra rotation makes them go too fast.
+		/// </summary>
+		void stopNebulas()
+		{
+			const EntityPointerManager* const epm = GetEntityPointerManager();
+			for (int i = 0; i < EntityPointerManager::MaxEntities; ++i)
+			{
+				const EntityPointer& entity = epm->m_entity_pointer[i];
+				if (entity.m_id.m_used && types::isNebula(entity.m_entity))
+				{
+					auto nebula = static_cast<types::Nebula*>(entity.m_entity);
+					nebula->delta_yaw = 0.0f;
+					nebula->delta_pitch = 0.0f;
+					nebula->delta_roll = 0.0f;
+				}
+			}
+		}
 	}
 
 	Worker::Worker( )
@@ -115,6 +138,7 @@ namespace mmm
 		instance = this;
 
 		enableSaveButtons();
+		stopNebulas();
 	}
 
 	Worker::~Worker( )


### PR DESCRIPTION
Stop the nebulas from rotating by default. They can have their own animations so they don't spin like they do currently.
Also add bindings for `deltaYaw`, `deltaPitch` and `deltaRoll` to the `Nebula` type, as well as the `allowConstruction` boolean property.
Closes #26