### PR TITLE
Allow setting race on GameObject

### DIFF
--- a/external/boost/preprocessor/debug/error.hpp
+++ b/external/boost/preprocessor/debug/error.hpp
@@ -1,0 +1,33 @@
+# /* **************************************************************************
+#  *                                                                          *
+#  *     (C) Copyright Paul Mensonides 2002.
+#  *     Distributed under the Boost Software License, Version 1.0. (See
+#  *     accompanying file LICENSE_1_0.txt or copy at
+#  *     http://www.boost.org/LICENSE_1_0.txt)
+#  *                                                                          *
+#  ************************************************************************** */
+#
+# /* See http://www.boost.org for most recent version. */
+#
+# ifndef BOOST_PREPROCESSOR_DEBUG_ERROR_HPP
+# define BOOST_PREPROCESSOR_DEBUG_ERROR_HPP
+#
+# include <boost/preprocessor/cat.hpp>
+# include <boost/preprocessor/config/config.hpp>
+#
+# /* BOOST_PP_ERROR */
+#
+# if BOOST_PP_CONFIG_ERRORS
+#    define BOOST_PP_ERROR(code) BOOST_PP_CAT(BOOST_PP_ERROR_, code)
+# endif
+#
+# define BOOST_PP_ERROR_0x0000 BOOST_PP_ERROR(0x0000, BOOST_PP_INDEX_OUT_OF_BOUNDS)
+# define BOOST_PP_ERROR_0x0001 BOOST_PP_ERROR(0x0001, BOOST_PP_WHILE_OVERFLOW)
+# define BOOST_PP_ERROR_0x0002 BOOST_PP_ERROR(0x0002, BOOST_PP_FOR_OVERFLOW)
+# define BOOST_PP_ERROR_0x0003 BOOST_PP_ERROR(0x0003, BOOST_PP_REPEAT_OVERFLOW)
+# define BOOST_PP_ERROR_0x0004 BOOST_PP_ERROR(0x0004, BOOST_PP_LIST_FOLD_OVERFLOW)
+# define BOOST_PP_ERROR_0x0005 BOOST_PP_ERROR(0x0005, BOOST_PP_SEQ_FOLD_OVERFLOW)
+# define BOOST_PP_ERROR_0x0006 BOOST_PP_ERROR(0x0006, BOOST_PP_ARITHMETIC_OVERFLOW)
+# define BOOST_PP_ERROR_0x0007 BOOST_PP_ERROR(0x0007, BOOST_PP_DIVISION_BY_ZERO)
+#
+# endif

--- a/mmm_armada/GameObjectBinding.cpp
+++ b/mmm_armada/GameObjectBinding.cpp
@@ -33,7 +33,7 @@ namespace mmm
 				.property( "perceivedTeam", &GameObject::getPerceivedTeam, &GameObject::setPerceivedTeam )
 				.property( "aiControlled", &GameObject::isAiControlled )
 				.property( "class", &GameObject::getClass )
-				.property( "race", &GameObject::getRace )
+				.property( "race", &GameObject::getRace, &GameObject::setRace )
 				.property("alpha", &GameObject::getAlpha, &GameObject::setAlpha)
 				.property("omega", &GameObject::getOmega, &GameObject::setOmega)
 				.property("accel", &GameObject::getAccel, &GameObject::setAccel)

--- a/mmm_armada/GameObject_Internal.cpp
+++ b/mmm_armada/GameObject_Internal.cpp
@@ -10,379 +10,384 @@
 
 namespace mmm
 {
-	namespace
-	{
-		const std::size_t Address_SetHealth			= 0x004d2080;
-		const std::size_t Address_SetMaximumHealth	= 0x004d2020;
-		const std::size_t Address_GetOdfName		= 0x004d5620;
-		const std::size_t Address_Cloak				= 0x004d5160;
-		const std::size_t Address_Decloak			= 0x004d51b0;
-		const std::size_t Address_CanCloak			= 0x004d51f0;
-		const std::size_t Address_ImmediateCloak	= 0x004d03e0;
-		const std::size_t Address_IsCloaked			= 0x004d03f0;
-		const std::size_t Address_SetTeam			= 0x004d0f10;
-		const std::size_t Address_SwapTeam			= 0x004d0ea0;
-		const std::size_t Address_IsAIControlled	= 0x004d5290;
-		const std::size_t Address_IsUnderAttack		= 0x004d1530; 
-		const std::size_t Address_GiveOrderPos		= 0x004d1b50;
-		const std::size_t Address_GiveOrderEnt		= 0x004d1af0;
-		const std::size_t Address_GiveOrderClassPos	= 0x004d1cb0;
-		const std::size_t Address_GiveOrderPath		= 0x004d1b80;
-	}
+    namespace
+    {
+        const std::size_t Address_SetHealth			= 0x004d2080;
+        const std::size_t Address_SetMaximumHealth	= 0x004d2020;
+        const std::size_t Address_GetOdfName		= 0x004d5620;
+        const std::size_t Address_Cloak				= 0x004d5160;
+        const std::size_t Address_Decloak			= 0x004d51b0;
+        const std::size_t Address_CanCloak			= 0x004d51f0;
+        const std::size_t Address_ImmediateCloak	= 0x004d03e0;
+        const std::size_t Address_IsCloaked			= 0x004d03f0;
+        const std::size_t Address_SetTeam			= 0x004d0f10;
+        const std::size_t Address_SwapTeam			= 0x004d0ea0;
+        const std::size_t Address_IsAIControlled	= 0x004d5290;
+        const std::size_t Address_IsUnderAttack		= 0x004d1530; 
+        const std::size_t Address_GiveOrderPos		= 0x004d1b50;
+        const std::size_t Address_GiveOrderEnt		= 0x004d1af0;
+        const std::size_t Address_GiveOrderClassPos	= 0x004d1cb0;
+        const std::size_t Address_GiveOrderPath		= 0x004d1b80;
+    }
 
-	GameObjectPtr 
-	GameObject::create( types::Entity* entity )
-	{
-		return GameObjectPtr( new GameObject( static_cast<types::GameObject*>( entity ) ) ); 
-	}
+    GameObjectPtr 
+    GameObject::create( types::Entity* entity )
+    {
+        return GameObjectPtr( new GameObject( static_cast<types::GameObject*>( entity ) ) ); 
+    }
 
-	GameObject::GameObject( types::GameObject* entity )
-		: Entity( entity ), ResourceInterface( entity )
-	{
-			
-	}
+    GameObject::GameObject( types::GameObject* entity )
+        : Entity( entity ), ResourceInterface( entity )
+    {
+            
+    }
 
-	types::GameObject* 
-	GameObject::getGameObject() const
-	{
-		return static_cast<types::GameObject*>( getEntity() );
-	}
+    types::GameObject* 
+    GameObject::getGameObject() const
+    {
+        return static_cast<types::GameObject*>( getEntity() );
+    }
 
-	const std::string
-	GameObject::getOdf( ) const
-	{
-		std::string odfname = (getGameObject()->*memory_function< const char* (types::GameObject::*) () >( Address_GetOdfName ))();
-		std::transform( odfname.begin(), odfname.end(), odfname.begin(), tolower );
-		return odfname;
-	}
+    const std::string
+    GameObject::getOdf( ) const
+    {
+        std::string odfname = (getGameObject()->*memory_function< const char* (types::GameObject::*) () >( Address_GetOdfName ))();
+        std::transform( odfname.begin(), odfname.end(), odfname.begin(), tolower );
+        return odfname;
+    }
 
-	const std::string
-	GameObject::getHandle( ) const
-	{
-		return getGameObject()->label;
-	}
+    const std::string
+    GameObject::getHandle( ) const
+    {
+        return getGameObject()->label;
+    }
 
-	bool
-	GameObject::getInvincible( ) const
-	{
-		types::GameObject* object = getGameObject();
-		return object->m_invincible != 0;
-	}
+    bool
+    GameObject::getInvincible( ) const
+    {
+        types::GameObject* object = getGameObject();
+        return object->m_invincible != 0;
+    }
 
-	const Vector3 
-	GameObject::getVelocity( ) const
-	{
-		types::GameObject* object = getGameObject();
-		return object->m_euler.m_vel;
-	}
+    const Vector3 
+    GameObject::getVelocity( ) const
+    {
+        types::GameObject* object = getGameObject();
+        return object->m_euler.m_vel;
+    }
 
-	TeamPtr
-	GameObject::getTeam( ) const 
-	{
-		types::GameObject* object = getGameObject();
-		return TeamPtr( new Team( object->teamNumber ) );
-	}
+    TeamPtr
+    GameObject::getTeam( ) const 
+    {
+        types::GameObject* object = getGameObject();
+        return TeamPtr( new Team( object->teamNumber ) );
+    }
 
-	TeamPtr
-	GameObject::getPerceivedTeam( ) const
-	{
-		types::GameObject* object = getGameObject();
-		return TeamPtr( new Team( object->perceivedTeam ) );
-	}
+    TeamPtr
+    GameObject::getPerceivedTeam( ) const
+    {
+        types::GameObject* object = getGameObject();
+        return TeamPtr( new Team( object->perceivedTeam ) );
+    }
 
-	float 
-	GameObject::getHealth( ) const
-	{
-		return getHitpoints() / getMaximumHealth();
-	}
+    float 
+    GameObject::getHealth( ) const
+    {
+        return getHitpoints() / getMaximumHealth();
+    }
 
-	float 
-	GameObject::getHitpoints( ) const
-	{
+    float 
+    GameObject::getHitpoints( ) const
+    {
         return getScriptInterface( )->GetCurrentHealth( getID() );
-	}
+    }
 
-	float 
-	GameObject::getMaximumHealth( ) const
-	{
-		return getScriptInterface( )->GetMaxHealth( getID() );
-	}
+    float 
+    GameObject::getMaximumHealth( ) const
+    {
+        return getScriptInterface( )->GetMaxHealth( getID() );
+    }
 
-	float
-	GameObject::getSpecialEnergy( ) const
-	{
-		return getGameObject()->m_curSpecialEnergy;
-	}
+    float
+    GameObject::getSpecialEnergy( ) const
+    {
+        return getGameObject()->m_curSpecialEnergy;
+    }
 
-	float
-	GameObject::getSpecialEnergyValue() const
-	{
-		return getSpecialEnergy() * getMaxSpecialEnergy();
-	}
+    float
+    GameObject::getSpecialEnergyValue() const
+    {
+        return getSpecialEnergy() * getMaxSpecialEnergy();
+    }
 
-	float
-	GameObject::getMaxSpecialEnergy( ) const
-	{
-		return getGameObject()->m_maxSpecialEnergy;
-	}
+    float
+    GameObject::getMaxSpecialEnergy( ) const
+    {
+        return getGameObject()->m_maxSpecialEnergy;
+    }
 
-	GameObjectClassPtr
-	GameObject::getClass( ) const
-	{
-		return createGameObjectClassPtr( getGameObject()->m_class );
-	}
+    GameObjectClassPtr
+    GameObject::getClass( ) const
+    {
+        return createGameObjectClassPtr( getGameObject()->m_class );
+    }
 
-	RacePtr				
-	GameObject::getRace() const
-	{
-		return RacePtr( new Race( getGameObject()->m_pRace ) );
-	}
+    RacePtr				
+    GameObject::getRace() const
+    {
+        return RacePtr( new Race( getGameObject()->m_pRace ) );
+    }
 
-	bool
-	GameObject::isDestroyed( ) const
-	{
-		types::GameObject* object = getGameObject();
-		return object->m_is_destroyed;
-	}
+    bool
+    GameObject::isDestroyed( ) const
+    {
+        types::GameObject* object = getGameObject();
+        return object->m_is_destroyed;
+    }
 
-	bool 
-	GameObject::isUnderAttack( ) const
-	{
-		float interval = 5.0f;
-		return (getGameObject()->*memory_function< bool (types::GameObject::*)(float) const >( Address_IsUnderAttack ))( interval );
-	}
+    bool 
+    GameObject::isUnderAttack( ) const
+    {
+        float interval = 5.0f;
+        return (getGameObject()->*memory_function< bool (types::GameObject::*)(float) const >( Address_IsUnderAttack ))( interval );
+    }
 
-	bool
-	GameObject::canCloak( ) const
-	{
-		return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_CanCloak ))();
-	}
+    bool
+    GameObject::canCloak( ) const
+    {
+        return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_CanCloak ))();
+    }
 
-	bool 
-	GameObject::isCloaked( ) const
-	{
-		return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_IsCloaked ))();
-	}
+    bool 
+    GameObject::isCloaked( ) const
+    {
+        return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_IsCloaked ))();
+    }
 
-	bool 
-	GameObject::isAiControlled( ) const
-	{
-		return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_IsAIControlled ))();
-	}
+    bool 
+    GameObject::isAiControlled( ) const
+    {
+        return (getGameObject()->*memory_function< bool (types::GameObject::*)() >( Address_IsAIControlled ))();
+    }
 
-	void 
-	GameObject::setInvincible( bool value )
-	{
-		types::GameObject* object = getGameObject();
-		object->m_invincible = value;
-	}
+    void 
+    GameObject::setInvincible( bool value )
+    {
+        types::GameObject* object = getGameObject();
+        object->m_invincible = value;
+    }
 
-	void 
-	GameObject::setHealth( float value )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetHealth ))( value * getMaximumHealth() );
-	}
+    void 
+    GameObject::setHealth( float value )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetHealth ))( value * getMaximumHealth() );
+    }
 
-	void 
-	GameObject::setHitpoints( float value )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetHealth ))( value );
-	}
+    void 
+    GameObject::setHitpoints( float value )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetHealth ))( value );
+    }
 
-	void 
-	GameObject::setMaximumHealth( float value )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetMaximumHealth ))( value );
-	}
+    void 
+    GameObject::setMaximumHealth( float value )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*) ( float ) >( Address_SetMaximumHealth ))( value );
+    }
 
-	void					
-	GameObject::setSpecialEnergy( float value )
-	{
-		getGameObject()->m_curSpecialEnergy = value * getMaxSpecialEnergy();
-	}
+    void					
+    GameObject::setSpecialEnergy( float value )
+    {
+        getGameObject()->m_curSpecialEnergy = value * getMaxSpecialEnergy();
+    }
 
-	void					
-	GameObject::setMaxSpecialEnergy( float value )
-	{
-		getGameObject()->m_maxSpecialEnergy = value;
-	}
+    void					
+    GameObject::setMaxSpecialEnergy( float value )
+    {
+        getGameObject()->m_maxSpecialEnergy = value;
+    }
 
-	void					
-	GameObject::setSpecialEnergyValue( float value )
-	{
-		getGameObject()->m_maxSpecialEnergy = value;
-	}
+    void					
+    GameObject::setSpecialEnergyValue( float value )
+    {
+        getGameObject()->m_maxSpecialEnergy = value;
+    }
 
-	void 
-	GameObject::setVelocity( const Vector3& vec )
-	{
-		getGameObject()->m_euler.m_vel = vec;
-	}
+    void 
+    GameObject::setVelocity( const Vector3& vec )
+    {
+        getGameObject()->m_euler.m_vel = vec;
+    }
 
-	void 
-	GameObject::setTeam( TeamPtr team )
-	{
-		types::GameObject* object = getGameObject();
-		object->teamNumber = team->getNumber();
-		object->perceivedTeam = team->getNumber();
-		object->m_pRace = team->getRace()->getRace();
-	}
+    void 
+    GameObject::setTeam( TeamPtr team )
+    {
+        types::GameObject* object = getGameObject();
+        object->teamNumber = team->getNumber();
+        object->perceivedTeam = team->getNumber();
+        object->m_pRace = team->getRace()->getRace();
+    }
 
-	void
-	GameObject::setPerceivedTeam( TeamPtr team )
-	{
-		types::GameObject* object = getGameObject();
-		object->perceivedTeam	= team->getNumber();
-		object->m_pRace			= team->getRace()->getRace();
-	}
+    void
+    GameObject::setPerceivedTeam( TeamPtr team )
+    {
+        types::GameObject* object = getGameObject();
+        object->perceivedTeam	= team->getNumber();
+        object->m_pRace			= team->getRace()->getRace();
+    }
 
-	bool
-	GameObject::getForceOntoMap( ) const
-	{
-		types::GameObject* object = getGameObject();
-		return 	object->m_force_onto_map;
-	}
+    bool
+    GameObject::getForceOntoMap( ) const
+    {
+        types::GameObject* object = getGameObject();
+        return 	object->m_force_onto_map;
+    }
 
-	void
-	GameObject::setForceOntoMap( bool value )
-	{
-		types::GameObject* object = getGameObject();
-		object->m_force_onto_map = value;
-	}
+    void
+    GameObject::setForceOntoMap( bool value )
+    {
+        types::GameObject* object = getGameObject();
+        object->m_force_onto_map = value;
+    }
 
-	void 
-	GameObject::cloak( )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_Cloak ))();
-	}
+    void 
+    GameObject::cloak( )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_Cloak ))();
+    }
 
-	void 
-	GameObject::decloak( )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_Decloak))();
-	}
+    void 
+    GameObject::decloak( )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_Decloak))();
+    }
 
-	void 
-	GameObject::immediateCloak( )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_ImmediateCloak ))();
-	}
+    void 
+    GameObject::immediateCloak( )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*)() >( Address_ImmediateCloak ))();
+    }
 
-	void 
-	GameObject::giveOrder( AiCommand order, const Vector3& pos )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, const Vector3&, long, bool )>( Address_GiveOrderPos ))
-			( order, pos, 0, false );
-	}
+    void 
+    GameObject::giveOrder( AiCommand order, const Vector3& pos )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, const Vector3&, long, bool )>( Address_GiveOrderPos ))
+            ( order, pos, 0, false );
+    }
 
-	void
-	GameObject::giveOrder( AiCommand order, EntityPtr ent )
-	{
-		if( ent->isType( Entity_GameObject ) )
-		{
-			(getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, const types::GameObject*, long, bool )>( Address_GiveOrderEnt ))
-				( order, boost::static_pointer_cast<GameObject>( ent )->getGameObject(), 0, false );
-		}
-	}
+    void
+    GameObject::giveOrder( AiCommand order, EntityPtr ent )
+    {
+        if( ent->isType( Entity_GameObject ) )
+        {
+            (getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, const types::GameObject*, long, bool )>( Address_GiveOrderEnt ))
+                ( order, boost::static_pointer_cast<GameObject>( ent )->getGameObject(), 0, false );
+        }
+    }
 
-	void
-	GameObject::giveOrder( AiCommand order, const std::string& cls, const Vector3& pos )
-	{
-		std::string lowerClassName(cls);
-		std::transform( lowerClassName.begin(), lowerClassName.end(), lowerClassName.begin(), ::tolower );
+    void
+    GameObject::giveOrder( AiCommand order, const std::string& cls, const Vector3& pos )
+    {
+        std::string lowerClassName(cls);
+        std::transform( lowerClassName.begin(), lowerClassName.end(), lowerClassName.begin(), ::tolower );
 
-		void* objectClass = FindGameObjectClass( lowerClassName.c_str( ) );
-		if( objectClass )
-		{
-			(getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, void*, const Vector3&, bool )>( Address_GiveOrderClassPos ))
-				( order, objectClass, pos, false );
-		}
-	}
+        void* objectClass = FindGameObjectClass( lowerClassName.c_str( ) );
+        if( objectClass )
+        {
+            (getGameObject()->*memory_function< void (types::GameObject::*)( AiCommand, void*, const Vector3&, bool )>( Address_GiveOrderClassPos ))
+                ( order, objectClass, pos, false );
+        }
+    }
 
-	void
-	GameObject::giveOrder( AiCommand order, const Path& path )
-	{
-		(getGameObject()->*memory_function< void (types::GameObject::*)(AiCommand, types::AiPath*, bool, bool)>( Address_GiveOrderPath ))
-			(order, path.getPath(), true, false );
-	}
+    void
+    GameObject::giveOrder( AiCommand order, const Path& path )
+    {
+        (getGameObject()->*memory_function< void (types::GameObject::*)(AiCommand, types::AiPath*, bool, bool)>( Address_GiveOrderPath ))
+            (order, path.getPath(), true, false );
+    }
 
-	void
-	GameObject::giveOrder( AiCommand order, long what )
-	{
-		getScriptInterface()->SetCommandWhatWhoParamVO( getGameObject()->m_entity_id,
-														order,
-														getGameObject()->m_entity_id,
-														what,
-														false );
-	}
+    void
+    GameObject::giveOrder( AiCommand order, long what )
+    {
+        getScriptInterface()->SetCommandWhatWhoParamVO( getGameObject()->m_entity_id,
+                                                        order,
+                                                        getGameObject()->m_entity_id,
+                                                        what,
+                                                        false );
+    }
 
-	void				
-	GameObject::giveOrder( AiCommand order )
-	{
-		getScriptInterface()->SetCommandWhatWhoParamVO( getGameObject()->m_entity_id,
-														order,
-														getGameObject()->m_entity_id,
-														0,
-														false );
-														
-	}
+    void				
+    GameObject::giveOrder( AiCommand order )
+    {
+        getScriptInterface()->SetCommandWhatWhoParamVO( getGameObject()->m_entity_id,
+                                                        order,
+                                                        getGameObject()->m_entity_id,
+                                                        0,
+                                                        false );
+                                                        
+    }
 
-	void				
-	GameObject::addWeapon( const std::string& weapon )
-	{
-		struct cPrjID
-		{
-			int m_id;
-		};
+    void				
+    GameObject::addWeapon( const std::string& weapon )
+    {
+        struct cPrjID
+        {
+            int m_id;
+        };
 
-		cPrjID testID = { 0 };
-		(testID.*memory_function< void (cPrjID::*)(const char*) >( 0x006593c0 ))( weapon.c_str() );
+        cPrjID testID = { 0 };
+        (testID.*memory_function< void (cPrjID::*)(const char*) >( 0x006593c0 ))( weapon.c_str() );
 
-		void* wpn = (memory_function< void* (*)(const cPrjID&) >( 0x00664850 ))( testID );
+        void* wpn = (memory_function< void* (*)(const cPrjID&) >( 0x00664850 ))( testID );
 
-		types::Carrier* carrier = static_cast<types::Carrier*>( getGameObject()->carrier );
-		(carrier->*memory_function< void (types::Carrier::*)(void*, unsigned char) >( 0x006682d0 ))(wpn, 0);
-	}
+        types::Carrier* carrier = static_cast<types::Carrier*>( getGameObject()->carrier );
+        (carrier->*memory_function< void (types::Carrier::*)(void*, unsigned char) >( 0x006682d0 ))(wpn, 0);
+    }
 
-	ResourceInterface
-	GameObject::getResourceInterface( ) const
-	{
-		return ResourceInterface( *this );
-	}
+    ResourceInterface
+    GameObject::getResourceInterface( ) const
+    {
+        return ResourceInterface( *this );
+    }
 
-	Vector3 GameObject::getAlpha() const
-	{
-		return getGameObject()->m_euler.alpha;
-	}
+    Vector3 GameObject::getAlpha() const
+    {
+        return getGameObject()->m_euler.alpha;
+    }
 
-	Vector3 GameObject::getOmega() const
-	{
-		return getGameObject()->m_euler.omega;
-	}
+    Vector3 GameObject::getOmega() const
+    {
+        return getGameObject()->m_euler.omega;
+    }
 
-	Vector3 GameObject::getAccel() const
-	{
-		return getGameObject()->m_euler.accel;
-	}
+    Vector3 GameObject::getAccel() const
+    {
+        return getGameObject()->m_euler.accel;
+    }
 
-	void GameObject::setAlpha(const Vector3& alpha)
-	{
-		getGameObject()->m_euler.alpha = alpha;
-	}
+    void GameObject::setAlpha(const Vector3& alpha)
+    {
+        getGameObject()->m_euler.alpha = alpha;
+    }
 
-	void GameObject::setOmega(const Vector3& omega)
-	{
-		getGameObject()->m_euler.omega = omega;
-	}
+    void GameObject::setOmega(const Vector3& omega)
+    {
+        getGameObject()->m_euler.omega = omega;
+    }
 
-	void GameObject::setAccel(const Vector3& accel)
-	{
-		getGameObject()->m_euler.accel = accel;
-	}
+    void GameObject::setAccel(const Vector3& accel)
+    {
+        getGameObject()->m_euler.accel = accel;
+    }
 
-	void 
-	GameObject::allocateReplacement( luabind::detail::object_rep* obj )
-	{
-		entity_allocate_replacement<GameObject>( obj, boost::static_pointer_cast<GameObject>( shared_from_this() ) );
-	}
+    void 
+    GameObject::allocateReplacement( luabind::detail::object_rep* obj )
+    {
+        entity_allocate_replacement<GameObject>( obj, boost::static_pointer_cast<GameObject>( shared_from_this() ) );
+    }
+
+    void GameObject::setRace(RacePtr race)
+    {
+        getGameObject()->m_pRace = race->getRace();
+    }
 }

--- a/mmm_armada/GameObject_Internal.h
+++ b/mmm_armada/GameObject_Internal.h
@@ -5,72 +5,73 @@
 
 namespace mmm
 {
-	namespace types
-	{
-		struct GameObject;
-	}
-		
-	class Path;
+    namespace types
+    {
+        struct GameObject;
+    }
 
-	class GameObject : public Entity, public ResourceInterface
-	{
-	public:
-		static GameObjectPtr create( types::Entity* entity );
-		virtual				~GameObject(){};
-		const std::string	getOdf( ) const;
-		const std::string	getHandle( ) const;
-		bool				getInvincible( ) const;
-		const Vector3		getVelocity( ) const;
-		TeamPtr				getTeam( ) const;
-		TeamPtr				getPerceivedTeam( ) const;
-		float				getHealth( ) const;
-		float				getHitpoints() const;
-		float				getMaximumHealth( ) const;
-		float				getSpecialEnergy( ) const;
-		float				getSpecialEnergyValue( ) const;
-		float				getMaxSpecialEnergy( ) const;
-		bool				getForceOntoMap( ) const;
-		GameObjectClassPtr  getClass() const;
-		RacePtr				getRace() const;
-		void				setHealth( float value );
-		void				setHitpoints( float value );
-		void				setMaximumHealth( float value );
-		void				setSpecialEnergy( float value );
-		void				setMaxSpecialEnergy( float value );
-		void				setSpecialEnergyValue( float value );
-		bool				isDestroyed( ) const;
-		bool				isUnderAttack( ) const;
-		bool				canCloak( ) const;
-		bool				isCloaked( ) const;
-		bool				isAiControlled( ) const;
-		void				setInvincible( bool value );
-		void				setVelocity( const Vector3& vec );
-		void				setTeam( TeamPtr team );
-		void				setPerceivedTeam( TeamPtr team );
-		void				setForceOntoMap( bool value );
-		void				cloak( );
-		void				decloak( );
-		void				immediateCloak( );
-		void				giveOrder( AiCommand order, const Vector3& pos );
-		void				giveOrder( AiCommand order, EntityPtr ent );
-		void				giveOrder( AiCommand order, const std::string& cls, const Vector3& pos );
-		void				giveOrder( AiCommand order, const Path& path );
-		void				giveOrder( AiCommand order, long value );
-		void				giveOrder( AiCommand order );
-		void				addWeapon( const std::string& weapon );
-		types::GameObject*	getGameObject() const;
-		ResourceInterface	getResourceInterface() const;
+    class Path;
 
-		Vector3 getAlpha() const;
-		Vector3 getOmega() const;
-		Vector3 getAccel() const;
-		void setAlpha(const Vector3& alpha);
-		void setOmega(const Vector3& omega);
-		void setAccel(const Vector3& accel);
-	protected:
-		explicit			GameObject( types::GameObject* entity );
-		virtual void allocateReplacement( luabind::detail::object_rep* obj );
-	};
+    class GameObject : public Entity, public ResourceInterface
+    {
+    public:
+        static GameObjectPtr create( types::Entity* entity );
+        virtual ~GameObject() = default;
+        const std::string   getOdf( ) const;
+        const std::string   getHandle( ) const;
+        bool                getInvincible( ) const;
+        const Vector3       getVelocity( ) const;
+        TeamPtr             getTeam( ) const;
+        TeamPtr             getPerceivedTeam( ) const;
+        float               getHealth( ) const;
+        float               getHitpoints() const;
+        float               getMaximumHealth( ) const;
+        float               getSpecialEnergy( ) const;
+        float               getSpecialEnergyValue( ) const;
+        float               getMaxSpecialEnergy( ) const;
+        bool                getForceOntoMap( ) const;
+        GameObjectClassPtr  getClass() const;
+        RacePtr             getRace() const;
+        void                setHealth( float value );
+        void                setHitpoints( float value );
+        void                setMaximumHealth( float value );
+        void                setSpecialEnergy( float value );
+        void                setMaxSpecialEnergy( float value );
+        void                setSpecialEnergyValue( float value );
+        bool                isDestroyed( ) const;
+        bool                isUnderAttack( ) const;
+        bool                canCloak( ) const;
+        bool                isCloaked( ) const;
+        bool                isAiControlled( ) const;
+        void                setInvincible( bool value );
+        void                setVelocity( const Vector3& vec );
+        void                setTeam( TeamPtr team );
+        void                setPerceivedTeam( TeamPtr team );
+        void                setForceOntoMap( bool value );
+        void                cloak( );
+        void                decloak( );
+        void                immediateCloak( );
+        void                giveOrder( AiCommand order, const Vector3& pos );
+        void                giveOrder( AiCommand order, EntityPtr ent );
+        void                giveOrder( AiCommand order, const std::string& cls, const Vector3& pos );
+        void                giveOrder( AiCommand order, const Path& path );
+        void                giveOrder( AiCommand order, long value );
+        void                giveOrder( AiCommand order );
+        void                addWeapon( const std::string& weapon );
+        types::GameObject*  getGameObject() const;
+        ResourceInterface   getResourceInterface() const;
 
-	void gameobject_register( lua_State* state );
+        Vector3 getAlpha() const;
+        Vector3 getOmega() const;
+        Vector3 getAccel() const;
+        void setAlpha(const Vector3& alpha);
+        void setOmega(const Vector3& omega);
+        void setAccel(const Vector3& accel);
+        void setRace(RacePtr race);
+    protected:
+        explicit            GameObject( types::GameObject* entity );
+        virtual void allocateReplacement( luabind::detail::object_rep* obj );
+    };
+
+    void gameobject_register( lua_State* state );
 }


### PR DESCRIPTION
Set the race of a GameObject with `.race`. No script interface function available for this, only for changing player race.
Also add missing boost file that was missed by too wide gitignore (in a debug folder)
Closes #37 
